### PR TITLE
Ruhail/api fixes

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1775,6 +1775,177 @@
           "Cleaning"
         ]
       }
+    },
+    "/api/v1/payments/create-checkout-with-booking": {
+      "post": {
+        "description": "Create a Stripe Checkout session with all booking details. Booking will be created in database only after successful payment.",
+        "operationId": "PaymentsController_createCheckoutWithBooking",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Booking and checkout session details",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCheckoutWithBookingDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Checkout session created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckoutSessionResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid booking details or room not available"
+          },
+          "500": {
+            "description": "Failed to create checkout session"
+          }
+        },
+        "summary": "Create Stripe checkout session with booking details",
+        "tags": [
+          "Payments"
+        ]
+      }
+    },
+    "/api/v1/payments/create-checkout-session": {
+      "post": {
+        "description": "Create a Stripe Checkout session for a pending booking. Returns a URL to redirect the user to complete payment.",
+        "operationId": "PaymentsController_createCheckoutSession",
+        "parameters": [],
+        "requestBody": {
+          "required": true,
+          "description": "Checkout session details",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCheckoutSessionDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Checkout session created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckoutSessionResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid booking ID or booking not in pending status"
+          },
+          "500": {
+            "description": "Failed to create checkout session"
+          }
+        },
+        "summary": "Create Stripe checkout session",
+        "tags": [
+          "Payments"
+        ]
+      }
+    },
+    "/api/v1/payments/stripe-webhook": {
+      "post": {
+        "description": "Endpoint for Stripe to send webhook events. Handles payment confirmations and failures.",
+        "operationId": "PaymentsController_handleStripeWebhook",
+        "parameters": [
+          {
+            "name": "stripe-signature",
+            "required": true,
+            "in": "header",
+            "description": "Stripe webhook signature for verification",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Webhook processed successfully"
+          },
+          "400": {
+            "description": "Invalid webhook signature or payload"
+          }
+        },
+        "summary": "Handle Stripe webhooks",
+        "tags": [
+          "Payments"
+        ]
+      }
+    },
+    "/api/v1/payments/success": {
+      "get": {
+        "description": "Retrieve payment success information using the Stripe session ID. Called after successful payment redirect.",
+        "operationId": "PaymentsController_getPaymentSuccess",
+        "parameters": [
+          {
+            "name": "session_id",
+            "required": true,
+            "in": "query",
+            "description": "Stripe checkout session ID from success URL",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment success details retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentSuccessResponseDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid or missing session ID"
+          }
+        },
+        "summary": "Get payment success details",
+        "tags": [
+          "Payments"
+        ]
+      }
+    },
+    "/api/v1/payments/cancel": {
+      "get": {
+        "description": "Endpoint called when user cancels payment. Returns information about the cancelled session.",
+        "operationId": "PaymentsController_handlePaymentCancel",
+        "parameters": [
+          {
+            "name": "session_id",
+            "required": false,
+            "in": "query",
+            "description": "Stripe checkout session ID (optional)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment cancellation handled"
+          }
+        },
+        "summary": "Handle payment cancellation",
+        "tags": [
+          "Payments"
+        ]
+      }
     }
   },
   "info": {
@@ -1805,11 +1976,11 @@
       "description": "Room inventory and availability"
     },
     {
-      "name": "bookings",
+      "name": "Bookings",
       "description": "Reservation management"
     },
     {
-      "name": "payments",
+      "name": "Payments",
       "description": "Payment processing"
     }
   ],
@@ -4055,6 +4226,158 @@
           "managers",
           "staff",
           "stats"
+        ]
+      },
+      "CreateCheckoutWithBookingDto": {
+        "type": "object",
+        "properties": {
+          "room_id": {
+            "type": "string",
+            "description": "Room ID to book",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "guest_name": {
+            "type": "string",
+            "description": "Guest full name",
+            "example": "John Doe"
+          },
+          "guest_email": {
+            "type": "string",
+            "description": "Guest email address",
+            "example": "john.doe@example.com"
+          },
+          "check_in_date": {
+            "type": "string",
+            "description": "Check-in date (YYYY-MM-DD)",
+            "example": "2025-07-15"
+          },
+          "check_out_date": {
+            "type": "string",
+            "description": "Check-out date (YYYY-MM-DD)",
+            "example": "2025-07-17"
+          },
+          "guest_contact": {
+            "type": "string",
+            "description": "Guest contact phone number (optional)",
+            "example": "+1-555-123-4567"
+          },
+          "source": {
+            "type": "string",
+            "description": "Booking source",
+            "example": "Website"
+          },
+          "adults": {
+            "type": "number",
+            "description": "Number of adults",
+            "example": 2
+          },
+          "infants": {
+            "type": "number",
+            "description": "Number of children/infants",
+            "example": 0
+          },
+          "success_url": {
+            "type": "string",
+            "description": "Success URL to redirect to after successful payment",
+            "example": "http://localhost:3000/payment/success"
+          },
+          "cancel_url": {
+            "type": "string",
+            "description": "Cancel URL to redirect to if payment is cancelled",
+            "example": "http://localhost:3000/payment/cancel"
+          }
+        },
+        "required": [
+          "room_id",
+          "guest_name",
+          "guest_email",
+          "check_in_date",
+          "check_out_date",
+          "adults",
+          "infants",
+          "success_url",
+          "cancel_url"
+        ]
+      },
+      "CheckoutSessionResponseDto": {
+        "type": "object",
+        "properties": {
+          "session_id": {
+            "type": "string",
+            "description": "Stripe Checkout Session ID",
+            "example": "cs_test_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6"
+          },
+          "checkout_url": {
+            "type": "string",
+            "description": "Stripe Checkout Session URL",
+            "example": "https://checkout.stripe.com/pay/cs_test_a1B2c3D4e5F6g7H8i9J0k1L2m3N4o5P6"
+          },
+          "booking_id": {
+            "type": "string",
+            "description": "Booking ID associated with this payment session",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          }
+        },
+        "required": [
+          "session_id",
+          "checkout_url",
+          "booking_id"
+        ]
+      },
+      "CreateCheckoutSessionDto": {
+        "type": "object",
+        "properties": {
+          "booking_id": {
+            "type": "string",
+            "description": "Booking ID to create payment session for",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "success_url": {
+            "type": "string",
+            "description": "Success URL to redirect to after successful payment",
+            "example": "http://localhost:3000/payment/success"
+          },
+          "cancel_url": {
+            "type": "string",
+            "description": "Cancel URL to redirect to if payment is cancelled",
+            "example": "http://localhost:3000/payment/cancel"
+          }
+        },
+        "required": [
+          "booking_id",
+          "success_url",
+          "cancel_url"
+        ]
+      },
+      "PaymentSuccessResponseDto": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Success message",
+            "example": "Payment completed successfully"
+          },
+          "booking_id": {
+            "type": "string",
+            "description": "Booking ID that was paid for",
+            "example": "550e8400-e29b-41d4-a716-446655440000"
+          },
+          "amount_paid": {
+            "type": "number",
+            "description": "Payment amount in cents",
+            "example": 15000
+          },
+          "payment_intent_id": {
+            "type": "string",
+            "description": "Stripe payment intent ID",
+            "example": "pi_1234567890abcdef"
+          }
+        },
+        "required": [
+          "message",
+          "booking_id",
+          "amount_paid",
+          "payment_intent_id"
         ]
       }
     }

--- a/prisma/migrations/20250708143012_convert_cents_to_euros/migration.sql
+++ b/prisma/migrations/20250708143012_convert_cents_to_euros/migration.sql
@@ -1,0 +1,21 @@
+-- Convert all monetary fields from cents (Int) to euros (DECIMAL)
+
+-- 1. Update Room table
+ALTER TABLE "rooms" 
+  ALTER COLUMN "base_price" TYPE DECIMAL(10,2) USING "base_price"::DECIMAL / 100,
+  ALTER COLUMN "airbnb_price" TYPE DECIMAL(10,2) USING "airbnb_price"::DECIMAL / 100,
+  ALTER COLUMN "booking_com_price" TYPE DECIMAL(10,2) USING "booking_com_price"::DECIMAL / 100,
+  ALTER COLUMN "pet_fee" TYPE DECIMAL(10,2) USING "pet_fee"::DECIMAL / 100,
+  ALTER COLUMN "cleaning_fee" TYPE DECIMAL(10,2) USING "cleaning_fee"::DECIMAL / 100;
+
+-- 2. Update Booking table
+ALTER TABLE "bookings"
+  ALTER COLUMN "total_cost" TYPE DECIMAL(10,2) USING "total_cost"::DECIMAL / 100;
+
+-- 3. Update Payment table
+ALTER TABLE "payments"
+  ALTER COLUMN "amount" TYPE DECIMAL(10,2) USING "amount"::DECIMAL / 100;
+
+-- 4. Update RateRule table
+ALTER TABLE "rate_rules"
+  ALTER COLUMN "price_per_night" TYPE DECIMAL(10,2) USING "price_per_night"::DECIMAL / 100;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,15 +94,15 @@ model Room {
   description       String?
   size_sqm          Int?
   bed_setup         String?
-  base_price        Int        // Price in cents (for website/direct bookings)
-  airbnb_price      Int?       // Price in cents for Airbnb (optional - defaults to base_price if null)
-  booking_com_price Int?       // Price in cents for Booking.com (optional - defaults to base_price if null)
+  base_price        Decimal    @db.Decimal(10,2) // Price in euros (for website/direct bookings)
+  airbnb_price      Decimal?   @db.Decimal(10,2) // Price in euros for Airbnb (optional - defaults to base_price if null)
+  booking_com_price Decimal?   @db.Decimal(10,2) // Price in euros for Booking.com (optional - defaults to base_price if null)
   max_capacity      Int
   status            RoomStatus @default(available)
   amenities         Json?
-  pet_fee           Int?       // Pet fee in cents
+  pet_fee           Decimal?   @db.Decimal(10,2) // Pet fee in euros
   minimum_nights    Int?       // Minimum nights required for booking
-  cleaning_fee      Int?       // Cleaning fee in cents
+  cleaning_fee      Decimal?   @db.Decimal(10,2) // Cleaning fee in euros
   created_at        DateTime   @default(now())
   updated_at        DateTime   @updatedAt
 
@@ -127,7 +127,7 @@ model Booking {
   guest_email      String
   check_in_date    DateTime      @db.Date
   check_out_date   DateTime      @db.Date
-  total_cost       Int           // Cost in cents
+  total_cost       Decimal       @db.Decimal(10,2) // Cost in euros
   status           BookingStatus @default(pending)
   source           String?
   created_at       DateTime      @default(now())
@@ -146,7 +146,7 @@ model Booking {
 model Payment {
   id             String        @id @default(uuid()) @db.Uuid
   booking_id     String        @db.Uuid
-  amount         Int           // Amount in cents
+  amount         Decimal       @db.Decimal(10,2) // Amount in euros
   payment_method PaymentMethod
   identifier     String?
   created_at     DateTime      @default(now())
@@ -189,7 +189,7 @@ model RateRule {
   room_id         String @db.Uuid
   start_date      DateTime @db.Date
   end_date        DateTime @db.Date
-  price_per_night Int    // Price in cents
+  price_per_night Decimal @db.Decimal(10,2) // Price in euros
   min_stay_nights Int?
   day_of_week     Int[]  // Array of integers (0-6, Sunday-Saturday)
   source          String?

--- a/src/bookings/bookings.service.ts
+++ b/src/bookings/bookings.service.ts
@@ -51,7 +51,7 @@ export class BookingsService {
       check_out_date: booking.check_out_date.toISOString().split('T')[0], // Format as YYYY-MM-DD
       status: booking.status,
       source: booking.source || undefined,
-      total_cost: booking.total_cost,
+      total_cost: parseFloat(booking.total_cost.toString()),
       created_at: booking.created_at.toISOString(),
       updated_at: booking.updated_at.toISOString(),
     }));
@@ -155,7 +155,7 @@ export class BookingsService {
       check_out_date: booking.check_out_date.toISOString().split('T')[0],
       status: booking.status,
       source: booking.source || undefined,
-      total_cost: booking.total_cost,
+      total_cost: parseFloat(booking.total_cost.toString()),
       created_at: booking.created_at.toISOString(),
       updated_at: booking.updated_at.toISOString(),
     };

--- a/src/stats/stats.service.ts
+++ b/src/stats/stats.service.ts
@@ -109,14 +109,14 @@ export class StatsService {
       },
     });
 
-    const totalRevenue = revenueData._sum.total_cost || 0;
+    const totalRevenue = parseFloat((revenueData._sum.total_cost || 0).toString()); // Convert Decimal to number
     const bookingCount = revenueData._count.id;
     const averageBookingValue =
-      bookingCount > 0 ? Math.round(totalRevenue / bookingCount) : 0;
+      bookingCount > 0 ? parseFloat((totalRevenue / bookingCount).toFixed(2)) : 0;
 
     return {
       month: `${year}-${month.toString().padStart(2, '0')}`,
-      total_revenue: totalRevenue,
+      total_revenue: parseFloat(totalRevenue.toFixed(2)),
       booking_count: bookingCount,
       average_booking_value: averageBookingValue,
     };
@@ -190,18 +190,18 @@ export class StatsService {
       occupiedRoomNights += Math.max(0, nights);
     });
 
-    const totalRevenue = revenueData._sum.total_cost || 0;
-    const adrCents =
+    const totalRevenue = parseFloat((revenueData._sum.total_cost || 0).toString()); // Convert Decimal to number
+    const adrEuros =
       occupiedRoomNights > 0
-        ? Math.round(totalRevenue / occupiedRoomNights)
+        ? parseFloat((totalRevenue / occupiedRoomNights).toFixed(2))
         : 0;
 
     return {
       start_date: startDate,
       end_date: endDate,
-      total_revenue: totalRevenue,
+      total_revenue: parseFloat(totalRevenue.toFixed(2)),
       occupied_room_nights: occupiedRoomNights,
-      adr_cents: adrCents,
+      adr_cents: adrEuros, // Still named adr_cents but contains euros
     };
   }
 
@@ -335,7 +335,7 @@ export class StatsService {
         room_name: booking.room.name,
         check_in_date: booking.check_in_date.toISOString().split('T')[0],
         check_out_date: booking.check_out_date.toISOString().split('T')[0],
-        total_cost: booking.total_cost,
+        total_cost: parseFloat(booking.total_cost.toString()), // Convert Decimal to number
         nights,
       };
     });
@@ -431,7 +431,7 @@ export class StatsService {
           guest_contact: booking.guest_contact || undefined,
           check_in_date: booking.check_in_date.toISOString().split('T')[0],
           check_out_date: booking.check_out_date.toISOString().split('T')[0],
-          total_cost: booking.total_cost,
+          total_cost: parseFloat(booking.total_cost.toString()), // Convert Decimal to number
           nights,
           booking_status: booking.status,
         };
@@ -442,7 +442,7 @@ export class StatsService {
         room_name: room.name,
         room_description: room.description || '',
         max_capacity: room.max_capacity,
-        base_price: room.base_price,
+        base_price: parseFloat(room.base_price.toString()), // Convert Decimal to number
         room_status: room.status,
         booking_status: bookingStatus,
         booking: currentBooking,
@@ -519,7 +519,7 @@ export class StatsService {
       const customer = customerMap.get(email);
 
       // Update customer totals
-      customer.total_spent += booking.total_cost;
+      customer.total_spent += parseFloat(booking.total_cost.toString()); // Convert Decimal to number
 
       // Update booking dates
       if (booking.created_at < customer.first_booking_date) {
@@ -543,7 +543,7 @@ export class StatsService {
         room_name: booking.room.name,
         check_in_date: booking.check_in_date.toISOString().split('T')[0],
         check_out_date: booking.check_out_date.toISOString().split('T')[0],
-        total_cost: booking.total_cost,
+        total_cost: parseFloat(booking.total_cost.toString()), // Convert Decimal to number
         nights,
         status: booking.status,
         source: booking.source || 'Website',
@@ -558,7 +558,7 @@ export class StatsService {
         name: customer.name,
         contact: customer.contact,
         total_bookings: customer.bookings.length,
-        total_spent: customer.total_spent,
+        total_spent: parseFloat(customer.total_spent.toFixed(2)), // Ensure proper euro formatting
         first_booking_date: customer.first_booking_date.toISOString(),
         last_booking_date: customer.last_booking_date.toISOString(),
         bookings: customer.bookings.sort(
@@ -574,7 +574,7 @@ export class StatsService {
 
     // Calculate total revenue (including all bookings to match individual customer totals)
     const totalRevenue = bookings.reduce(
-      (sum, booking) => sum + booking.total_cost,
+      (sum, booking) => sum + parseFloat(booking.total_cost.toString()), // Convert Decimal to number
       0,
     );
 
@@ -601,8 +601,8 @@ export class StatsService {
       returning_customers_percentage:
         Math.round(returningCustomersPercentage * 100) / 100, // Round to 2 decimal places
       total_bookings: totalBookings,
-      total_revenue: totalRevenue,
-      average_customer_value: Math.round(averageCustomerValue),
+      total_revenue: parseFloat(totalRevenue.toFixed(2)),
+      average_customer_value: parseFloat(averageCustomerValue.toFixed(2)),
       customers,
     };
   }
@@ -655,7 +655,7 @@ export class StatsService {
         room_name: booking.room.name,
         check_in_date: booking.check_in_date.toISOString().split('T')[0],
         check_out_date: booking.check_out_date.toISOString().split('T')[0],
-        total_cost: booking.total_cost,
+        total_cost: parseFloat(booking.total_cost.toString()), // Convert Decimal to number
         nights,
       };
     });
@@ -748,7 +748,7 @@ export class StatsService {
           booking.check_in_date >= startDate &&
           booking.check_in_date <= endDate
         ) {
-          monthlyRevenue += booking.total_cost;
+          monthlyRevenue += parseFloat(booking.total_cost.toString()); // Convert Decimal to number
         }
       });
 
@@ -775,7 +775,7 @@ export class StatsService {
         occupied_room_nights: occupiedRoomNights,
         occupancy_rate: Math.round(occupancyRate * 100) / 100,
         total_bookings: monthlyBookings,
-        total_revenue: monthlyRevenue,
+        total_revenue: parseFloat(monthlyRevenue.toFixed(2)), // Format euros properly
       });
 
       totalYearlyRevenue += monthlyRevenue;
@@ -791,7 +791,7 @@ export class StatsService {
       hotel_id: hotelId,
       total_rooms: totalRooms,
       average_occupancy_rate: Math.round(averageOccupancyRate * 100) / 100,
-      total_yearly_revenue: totalYearlyRevenue,
+      total_yearly_revenue: parseFloat(totalYearlyRevenue.toFixed(2)), // Format euros properly
       months: monthlyData,
     };
   }


### PR DESCRIPTION
 feat: Convert entire pricing system from cents to euros

  - Create database migration to convert all monetary fields from INT (cents) to DECIMAL(10,2) (euros)
  - Update Prisma schema to use DECIMAL types for all price fields (base_price, airbnb_price, booking_com_price,
  pet_fee, cleaning_fee, total_cost, amount, price_per_night)
  - Fix all backend services to convert Prisma Decimal types to numbers for API responses
  - Update payment service to handle euro calculations and Stripe integration
  - Remove cents-to-euros conversion from statistics service since DB now stores euros directly
  - Fix React Query hook usage conflicts in frontend components
  - Ensure all monetary values display consistently in euros with 2 decimal places
  - Maintain Stripe integration by converting euros to cents only for payment processin